### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -1,5 +1,5 @@
 'use strict';  // eslint-disable-line
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const Command = require('../ember-cli/lib/models/command');
 const log = require('../utils/log')('atomable');
 const serverlessDeploy = require('../tasks/deploy/serverless');

--- a/ember-cli/lib/cli/index.js
+++ b/ember-cli/lib/cli/index.js
@@ -38,7 +38,7 @@ function clientId() {
   if (id) {
     return id;
   } else {
-    id = require('node-uuid').v4().toString();
+    id = require('uuid').v4().toString();
     configStore.set('client-id', id);
     return id;
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "leek": "0.0.24",
     "liftjs": "^1.2.0",
     "node-modules-path": "^1.0.1",
-    "node-uuid": "1.4.7",
     "nopt": "^3.0.6",
     "npm-package-arg": "^4.2.0",
     "ora": "^0.3.0",
@@ -56,6 +55,7 @@
     "serverless": "https://github.com/pre63/serverless",
     "silent-error": "^1.0.1",
     "through": "^2.3.8",
+    "uuid": "^3.0.0",
     "walk-sync": "^0.3.1",
     "webpack": "1.13.3",
     "yam": "^0.0.22"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.